### PR TITLE
fix editor.js for Firefox 27/Aurora

### DIFF
--- a/content/editor.js
+++ b/content/editor.js
@@ -9,7 +9,7 @@
 let global = this;
 const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
 Cu.import("resource://gre/modules/Services.jsm");
-Cu.import("resource:///modules/source-editor.jsm");
+Cu.import("resource:///modules/devtools/sourceeditor/source-editor.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 Cu.import("resource://gre/modules/NetUtil.jsm");
 Cu.import("resource://gre/modules/FileUtils.jsm");


### PR DESCRIPTION
The extension stops working somewhere between 2013-10-25    and 2013-10-31 builds of Aurora.
Probably needs more fixes, i see some errors in the browser console.
